### PR TITLE
fix: Correct the argument check of "drivername"

### DIFF
--- a/kea2/keaUtils.py
+++ b/kea2/keaUtils.py
@@ -182,6 +182,9 @@ class Options:
         if self.throttle < 0:
             raise ValueError("--throttle should be greater than or equal to 0")
 
+        if self.agent == 'u2' and self.driverName == None:
+            raise ValueError("--driver-name should be specified when customizing script in --agent u2")
+        
         _check_package_installation(self.packageNames)
 
 

--- a/kea2/kea_launcher.py
+++ b/kea2/kea_launcher.py
@@ -184,11 +184,6 @@ def parse_args(argv: List):
 
 
 def _sanitize_args(args):
-    if args.agent == "u2" and not args.driver_name:
-        if args.extra == []:
-            args.driver_name = "d"
-        else:
-            raise ValueError("--driver-name should be specified when customizing script in --agent u2")
     setattr(args, "unittest_args", []) #Assign the default value prior to other assignments.
     if args.extra:
         args.extra = args.extra[1:] if args.extra[0] == "--" else args.extra


### PR DESCRIPTION
Solve the #83 PR:
When using --agent native, "--driver-name" is not required.
When using --agent u2, "--driver-name" is required and should be explicitly specified by the user; otherwise, a ValueError will be thrown.