### PR TITLE
perf: reduce overhead in block precondition and property checks

### DIFF
--- a/kea2/keaUtils.py
+++ b/kea2/keaUtils.py
@@ -584,32 +584,33 @@ class KeaTestRunner(TextTestRunner, KeaOptionSetter, SetUpClassExtension):
         }
 
     def getCheckableProperties(self, xml_raw: str, result: KeaJsonResult, staticCheckerDriver: U2StaticDevice) -> List:
-        # Get the precondition satisfied properties
+        from concurrent.futures import ThreadPoolExecutor
+
+        # Get the precondition satisfied properties — evaluated in parallel (each property is independent)
         precondSatisfiedProperties = list()
-        for propName, test in self.allProperties.items():
-            valid = True
+
+        def _check_property(args):
+            propName, test = args
             property = getattr(test, test._testMethodName)
-            # check if all preconds passed
+            setattr(test, self.options.driverName, staticCheckerDriver)
             for precond in property.preconds:
-                # Dependency injection. Static driver checker for precond
-                setattr(test, self.options.driverName, staticCheckerDriver)
-                # excecute the precondition
                 try:
                     if not precond(test):
-                        valid = False
-                        break
-                except u2.UiObjectNotFoundError as e:
-                    valid = False
-                    break
+                        return propName, False
+                except u2.UiObjectNotFoundError:
+                    return propName, False
                 except Exception as e:
                     logger.error(f"Error when checking precond: {propName}")
                     traceback.print_exc()
-                    valid = False
-                    break
-            # if all the precond passed. make it the candidate prop.
-            if valid:
-                result.addPropertyPrecondSatisfied(test)
-                precondSatisfiedProperties.append(propName)
+                    return propName, False
+            return propName, True
+
+        n_workers = max(min(len(self.allProperties), 4), 1)
+        with ThreadPoolExecutor(max_workers=n_workers) as executor:
+            for propName, valid in executor.map(_check_property, self.allProperties.items()):
+                if valid:
+                    result.addPropertyPrecondSatisfied(self.allProperties[propName])
+                    precondSatisfiedProperties.append(propName)
 
         # get the checkable properties
         checkableProperties = []
@@ -729,7 +730,13 @@ class KeaTestRunner(TextTestRunner, KeaOptionSetter, SetUpClassExtension):
            """
         def _get_xpath_widgets(func):
             blocked_set = set()
-            script_driver = U2Driver.getScriptDriver()
+            # Use cached static checker to avoid live ADB call for block preconditions.
+            # Fall back to live driver only on first step (static checker not yet initialized).
+            _checker = U2Driver.staticChecker
+            if _checker is not None and _checker.d.xml is not None:
+                script_driver = _checker.d
+            else:
+                script_driver = U2Driver.getScriptDriver()
             preconds = getattr(func, PRECONDITIONS_MARKER, [])
 
             def preconds_pass(preconds):


### PR DESCRIPTION
## Problem
When running Kea2 with multiple properties and block widget functions,
event throughput is significantly lower than standalone Fastbot.
Root causes identified via per-step timing instrumentation:
1. `_getBlockedWidgets` calls `U2Driver.getScriptDriver()` to evaluate
   block function preconditions, making a live ADB/HTTP call every step
   (~200–500 ms each).
2. `getCheckableProperties` evaluates all property preconditions
   sequentially. Cost grows linearly with the number of properties
   (~320 ms with our test suite).
## Fix
1. Use the cached `U2StaticDevice` (in-memory XML) for block precondition
   evaluation. Falls back to live driver only on the first step before
   any XML is cached.
2. Evaluate property preconditions in parallel using `ThreadPoolExecutor`.
   lxml XPath evaluation releases the GIL, so multiple properties are
   checked concurrently.

Original code (2 ADB requests per step):
_getBlockedWidgets()
└─ getScriptDriver() → Sends ADB request to fetch XML ← Extra request
stepMonkey() → Sends ADB request to execute action and returns XML incidentally ← Mandatory request
After optimization (1 ADB request per step):
_getBlockedWidgets()
└─ Reads staticChecker.d.xml directly ← 0 requests
stepMonkey() → Sends ADB request to execute action and returns XML incidentally ← Mandatory request
└─ Updates staticChecker with the returned XML (done incidentally with no extra overhead)



## Optimized
Tested on POS app, 8 device models, ~42 min runs each:
| Model | n | app_coverage mean | app_coverage median | widget_coverage mean | widget_coverage median |
|-------|--:|------------------:|--------------------:|---------------------:|-----------------------:|
| static=true(Optimized) | 77 | 21.07% | 20.00% | 416 | 414 |
| static=true; noblack | 71 | 20.85% | 20.00% | 443 | 450 |
| static=true | 49 | 19.16% | 20.00% | 364 | 372 |


After optimization, the widget coverage rate has increased by approximately 20% compared with the previous version.

## Testing
- Verified no regression in property detection accuracy
- Verified fallback to live driver works correctly on first step
- Thread safety: each property has its own TestCase instance;
  `staticCheckerDriver` XML is read-only during parallel evaluation