### PR TITLE
feat: support historical Fastbot SO versions

### DIFF
--- a/docs/manual_cn.md
+++ b/docs/manual_cn.md
@@ -163,9 +163,20 @@ def test_func1(self):
 | --post-failure-screenshots | 失败后截取的截图数量。应小于等于 `--pre-failure-screenshots`。该选项仅在 `--take-screenshots` 设置时有效。 | `0` |
 | --restart-app-period | 运行过程中重启被测应用的周期（随机事件数）。 | `0`（不重启） |
 | --fastbot-agent | Fastbot Agent 策略，可选：`double-sarsa`、`sarsa`。 | `double-sarsa` |
+| --fastbot-so-version | 使用历史版本的 Fastbot native SO，并自动下载。推荐传 Git tag，例如 `v1.2.3`；也可传 commit SHA。 | 当前版本 SO 库 |
 | --device-output-root | 设备输出目录根路径，Kea2 将暂存截图和结果日志到 `"<device-output-root>/output_*********/"`。确保该目录可访问。 | `/sdcard` |
 | --act-whitelist-file | Activity 白名单文件。可传自定义路径；若只写参数名不带值，则默认 `/sdcard/.kea2/awl.strings`。 |  |
 | --act-blacklist-file | Activity 黑名单文件。可传自定义路径；若只写参数名不带值，则默认 `/sdcard/.kea2/abl.strings`。 |  |
+
+#### 使用历史版本 Fastbot SO
+
+默认情况下，Kea2 推送安装包中内置的 Fastbot native SO。需要使用历史版本时，通过 `--fastbot-so-version` 指定对应的 Git tag。常用格式为 `v1.2.3`（包含前缀 `v`）：
+
+```bash
+kea2 run -p com.example.app --fastbot-so-version v1.2.3
+```
+
+Kea2 会在推送到设备前将缺失 ABI 的 SO 下载到本地缓存。日志会记录实际推送的 SO 版本。没有对应 tag 时，也可以传 commit SHA。
 
 ### 1.2 子命令及其参数
 

--- a/docs/manual_cn.md
+++ b/docs/manual_cn.md
@@ -163,14 +163,14 @@ def test_func1(self):
 | --post-failure-screenshots | 失败后截取的截图数量。应小于等于 `--pre-failure-screenshots`。该选项仅在 `--take-screenshots` 设置时有效。 | `0` |
 | --restart-app-period | 运行过程中重启被测应用的周期（随机事件数）。 | `0`（不重启） |
 | --fastbot-agent | Fastbot Agent 策略，可选：`double-sarsa`、`sarsa`。 | `double-sarsa` |
-| --fastbot-so-version | 使用历史版本的 Fastbot native SO，并自动下载。推荐传 Git tag，例如 `v1.2.3`；也可传 commit SHA。 | 当前版本 SO 库 |
+| --fastbot-so-version | 使用历史版本的 Fastbot native SO，并自动下载。推荐传 Git tag，例如 `v1.2.3`；也可传 commit SHA。 | 当前 Kea2 版本内置的 SO 库 |
 | --device-output-root | 设备输出目录根路径，Kea2 将暂存截图和结果日志到 `"<device-output-root>/output_*********/"`。确保该目录可访问。 | `/sdcard` |
 | --act-whitelist-file | Activity 白名单文件。可传自定义路径；若只写参数名不带值，则默认 `/sdcard/.kea2/awl.strings`。 |  |
 | --act-blacklist-file | Activity 黑名单文件。可传自定义路径；若只写参数名不带值，则默认 `/sdcard/.kea2/abl.strings`。 |  |
 
 #### 使用历史版本 Fastbot SO
 
-默认情况下，Kea2 推送安装包中内置的 Fastbot native SO。需要使用历史版本时，通过 `--fastbot-so-version` 指定对应的 Git tag。常用格式为 `v1.2.3`（包含前缀 `v`）：
+默认情况下，Kea2 推送当前 Kea2 版本内置的 Fastbot native SO。需要使用历史版本时，通过 `--fastbot-so-version` 指定对应的 Git tag。常用格式为 `v1.2.3`（包含前缀 `v`）：
 
 ```bash
 kea2 run -p com.example.app --fastbot-so-version v1.2.3

--- a/docs/manual_en.md
+++ b/docs/manual_en.md
@@ -173,7 +173,7 @@ You can launch Kea2 by shell commands `kea2 run`.
 | --post-failure-screenshots | Dump n screenshots after failure. Should be smaller than `--pre-failure-screenshots`. This option is only valid when `--take-screenshots` is set.                                                                                                                     | `0` |
 | --restart-app-period       | The period (in the numbers of monkey events) to restart the app under test.                                                                                                                                                                                           | `0` (never restart) |
 | --fastbot-agent            | Fastbot agent strategy. Available options: `double-sarsa`, `sarsa`. | `double-sarsa` |
-| --fastbot-so-version       | Use a historical Fastbot native SO version and download it automatically. Use a Git tag such as `v1.2.3` (recommended) or a commit SHA. | current bundled SO libraries |
+| --fastbot-so-version       | Use a historical Fastbot native SO version and download it automatically. Use a Git tag such as `v1.2.3` (recommended) or a commit SHA. | SO libraries bundled with the current Kea2 version |
 | --device-output-root       | The root of device output dir. Kea2 will temporarily save the screenshots and result log into `"<device-output-root>/output_*********/"`. Make sure the root dir can be access.                                                                                       | `/sdcard` |
 | --act-whitelist-file       | Activity WhiteList File. You can pass a custom path, or omit the value to use `/sdcard/.kea2/awl.strings`.                                                                                                                                                            | |
 | --act-blacklist-file       | Activity BlackList File. You can pass a custom path, or omit the value to use `/sdcard/.kea2/abl.strings`.                                                                                                                                                            | |
@@ -181,7 +181,7 @@ You can launch Kea2 by shell commands `kea2 run`.
 
 #### Historical Fastbot SO versions
 
-By default, Kea2 pushes the Fastbot native SO libraries bundled with the installed package. To use a historical version, pass `--fastbot-so-version` with its Git tag. The usual tag format is `v1.2.3` (including the `v`):
+By default, Kea2 pushes the Fastbot native SO libraries bundled with the current Kea2 version. To use a historical version, pass `--fastbot-so-version` with its Git tag. The usual tag format is `v1.2.3` (including the `v`):
 
 ```bash
 kea2 run -p com.example.app --fastbot-so-version v1.2.3

--- a/docs/manual_en.md
+++ b/docs/manual_en.md
@@ -173,10 +173,21 @@ You can launch Kea2 by shell commands `kea2 run`.
 | --post-failure-screenshots | Dump n screenshots after failure. Should be smaller than `--pre-failure-screenshots`. This option is only valid when `--take-screenshots` is set.                                                                                                                     | `0` |
 | --restart-app-period       | The period (in the numbers of monkey events) to restart the app under test.                                                                                                                                                                                           | `0` (never restart) |
 | --fastbot-agent            | Fastbot agent strategy. Available options: `double-sarsa`, `sarsa`. | `double-sarsa` |
+| --fastbot-so-version       | Use a historical Fastbot native SO version and download it automatically. Use a Git tag such as `v1.2.3` (recommended) or a commit SHA. | current bundled SO libraries |
 | --device-output-root       | The root of device output dir. Kea2 will temporarily save the screenshots and result log into `"<device-output-root>/output_*********/"`. Make sure the root dir can be access.                                                                                       | `/sdcard` |
 | --act-whitelist-file       | Activity WhiteList File. You can pass a custom path, or omit the value to use `/sdcard/.kea2/awl.strings`.                                                                                                                                                            | |
 | --act-blacklist-file       | Activity BlackList File. You can pass a custom path, or omit the value to use `/sdcard/.kea2/abl.strings`.                                                                                                                                                            | |
 | --merge-fbm                | Enable FBM merge at startup. Pulls FBM(s) from the device and merges with local PC FBM data. The FBM file path on the local PC is in `configs/merge_fbm`.                                                                                                             | |
+
+#### Historical Fastbot SO versions
+
+By default, Kea2 pushes the Fastbot native SO libraries bundled with the installed package. To use a historical version, pass `--fastbot-so-version` with its Git tag. The usual tag format is `v1.2.3` (including the `v`):
+
+```bash
+kea2 run -p com.example.app --fastbot-so-version v1.2.3
+```
+
+Kea2 downloads any missing ABI libraries to the local cache before pushing them to the device. The log records the SO version being pushed. A commit SHA is also accepted when a tag is unavailable.
 
 ### 1.2 Sub-commands and their arguments
 Kea2 supports 3 sub-commands: `propertytest`, `unittest`, and `--` (extra arguments).

--- a/kea2/fastbotManager.py
+++ b/kea2/fastbotManager.py
@@ -11,6 +11,7 @@ from packaging.version import parse as parse_version
 
 from .utils import getLogger, getProjectRoot
 from .adbUtils import ADBDevice, ADBStreamShell_V2
+from .fastbot_so_downloader import ensure_libraries
 
 
 from typing import IO, TYPE_CHECKING, Dict
@@ -146,6 +147,13 @@ class FastbotManager:
     def _push_libs(self):
         logger.info("Pushing Fastbot libraries to device...")
         cur_dir = Path(__file__).parent
+        so_version = self.options.fastbot_so_version
+        if so_version:
+            native_lib_dir = ensure_libraries(so_version, progress=logger.info)
+            logger.info("Pushing Fastbot native SO libraries to device (version: %s).", so_version)
+        else:
+            native_lib_dir = cur_dir / "assets/fastbot_libs"
+            logger.info("Pushing Fastbot native SO libraries to device (version: current bundled).")
         self.dev.sync.push(
             Path.joinpath(cur_dir, "assets/monkeyq.jar"),
             "/sdcard/monkeyq.jar"
@@ -163,19 +171,19 @@ class FastbotManager:
             "/sdcard/framework.jar",
         )
         self.dev.sync.push(
-            Path.joinpath(cur_dir, "assets/fastbot_libs/arm64-v8a/libfastbot_native.so"),
+            native_lib_dir / "arm64-v8a/libfastbot_native.so",
             "/data/local/tmp/arm64-v8a/libfastbot_native.so",
         )
         self.dev.sync.push(
-            Path.joinpath(cur_dir, "assets/fastbot_libs/armeabi-v7a/libfastbot_native.so"),
+            native_lib_dir / "armeabi-v7a/libfastbot_native.so",
             "/data/local/tmp/armeabi-v7a/libfastbot_native.so",
         )
         self.dev.sync.push(
-            Path.joinpath(cur_dir, "assets/fastbot_libs/x86/libfastbot_native.so"),
+            native_lib_dir / "x86/libfastbot_native.so",
             "/data/local/tmp/x86/libfastbot_native.so",
         )
         self.dev.sync.push(
-            Path.joinpath(cur_dir, "assets/fastbot_libs/x86_64/libfastbot_native.so"),
+            native_lib_dir / "x86_64/libfastbot_native.so",
             "/data/local/tmp/x86_64/libfastbot_native.so",
         )
 
@@ -248,4 +256,3 @@ class FastbotManager:
 
     def join(self):
         self.thread.join()
-

--- a/kea2/fastbotManager.py
+++ b/kea2/fastbotManager.py
@@ -12,6 +12,7 @@ from packaging.version import parse as parse_version
 from .utils import getLogger, getProjectRoot
 from .adbUtils import ADBDevice, ADBStreamShell_V2
 from .fastbot_so_downloader import ensure_libraries
+from .version_manager import get_cur_version
 
 
 from typing import IO, TYPE_CHECKING, Dict
@@ -153,7 +154,7 @@ class FastbotManager:
             logger.info("Pushing Fastbot native SO libraries to device (version: %s).", so_version)
         else:
             native_lib_dir = cur_dir / "assets/fastbot_libs"
-            logger.info("Pushing Fastbot native SO libraries to device (version: current bundled).")
+            logger.info("Pushing Fastbot native SO libraries to device (version: %s).", get_cur_version())
         self.dev.sync.push(
             Path.joinpath(cur_dir, "assets/monkeyq.jar"),
             "/sdcard/monkeyq.jar"

--- a/kea2/fastbot_so_downloader.py
+++ b/kea2/fastbot_so_downloader.py
@@ -1,0 +1,108 @@
+"""Download historical Fastbot native libraries into a local cache."""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Callable, Iterable
+from urllib.error import HTTPError, URLError
+from urllib.request import urlopen
+
+
+REPOSITORY = "ecnusse/Kea2"
+GITEE_REPOSITORY = "XixianLiang/Kea2"
+ABIS = ("armeabi-v7a", "arm64-v8a", "x86", "x86_64")
+LIBRARY_NAME = "libfastbot_native.so"
+GIT_REF_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,127}$")
+
+
+def default_cache_dir() -> Path:
+    if platform.system() == "Darwin":
+        cache_home = Path.home() / "Library" / "Caches"
+    else:
+        cache_home = Path(os.environ.get("XDG_CACHE_HOME", Path.home() / ".cache"))
+    return cache_home / "kea2" / "fastbot_libs"
+
+
+def library_path(cache_dir: Path, version: str, abi: str) -> Path:
+    return cache_dir / version / abi / LIBRARY_NAME
+
+
+def is_valid_library(path: Path) -> bool:
+    try:
+        with path.open("rb") as library:
+            return library.read(4) == b"\x7fELF"
+    except OSError:
+        return False
+
+
+def raw_library_urls(version: str, abi: str) -> tuple[tuple[str, str], ...]:
+    path = f"kea2/assets/fastbot_libs/{abi}/{LIBRARY_NAME}"
+    return (
+        ("GitHub", f"https://raw.githubusercontent.com/{REPOSITORY}/{version}/{path}"),
+        ("Gitee", f"https://gitee.com/{GITEE_REPOSITORY}/raw/{version}/{path}"),
+    )
+
+
+def download_file(url: str, destination: Path, timeout: int) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(dir=destination.parent, prefix=f".{destination.name}.", delete=False) as output:
+        temporary_path = Path(output.name)
+        try:
+            with urlopen(url, timeout=timeout) as response:
+                shutil.copyfileobj(response, output)
+            output.flush()
+            os.fsync(output.fileno())
+            if not is_valid_library(temporary_path):
+                raise ValueError("downloaded file is not a valid ELF shared library")
+            temporary_path.replace(destination)
+        except Exception:
+            temporary_path.unlink(missing_ok=True)
+            raise
+
+
+def missing_abis(cache_dir: Path, version: str, force: bool = False) -> Iterable[str]:
+    for abi in ABIS:
+        if force or not is_valid_library(library_path(cache_dir, version, abi)):
+            yield abi
+
+
+def ensure_libraries(
+    version: str,
+    cache_dir: Path | None = None,
+    timeout: int = 30,
+    force: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> Path:
+    """Ensure all ABI libraries for *version* are cached and return their root."""
+    if not GIT_REF_PATTERN.fullmatch(version):
+        raise ValueError("--fastbot-so-version must contain only letters, digits, '.', '_' and '-'")
+    if timeout <= 0:
+        raise ValueError("timeout must be greater than 0")
+
+    cache_dir = cache_dir or default_cache_dir()
+    pending = list(missing_abis(cache_dir, version, force=force))
+    if not pending:
+        return cache_dir / version
+
+    for abi in pending:
+        target = library_path(cache_dir, version, abi)
+        errors = []
+        for source, url in raw_library_urls(version, abi):
+            if progress:
+                progress(f"Downloading Fastbot SO {version} ({abi}) from {source}: {url}")
+            try:
+                download_file(url, target, timeout)
+                break
+            except HTTPError as error:
+                errors.append(f"{source}: HTTP {error.code}")
+            except (URLError, OSError, ValueError) as error:
+                errors.append(f"{source}: {error}")
+        else:
+            raise RuntimeError(f"Failed to download Fastbot SO {version} for {abi}; {'; '.join(errors)}")
+
+    return cache_dir / version

--- a/kea2/keaUtils.py
+++ b/kea2/keaUtils.py
@@ -143,6 +143,8 @@ class Options:
     act_blacklist_file: str = None
     # Fastbot Agent
     fastbot_agent: Literal["double-sarsa", "sarsa"] = "double-sarsa"
+    # Optional Git tag or commit ref for downloaded Fastbot native SO libraries
+    fastbot_so_version: str = None
     # propertytest sub-commands args (eg. discover -s xxx -p xxx)
     propertytest_args: List[str] = None
     # period (N steps) to restart the app under test

--- a/kea2/kea_launcher.py
+++ b/kea2/kea_launcher.py
@@ -172,6 +172,15 @@ def _set_runner_parser(subparsers: "argparse._SubParsersAction[argparse.Argument
         help="Fastbot agent strategy.",
     )
 
+    parser.add_argument(
+        "--fastbot-so-version",
+        dest="fastbot_so_version",
+        type=str,
+        required=False,
+        default=None,
+        help="Use a historical Fastbot native SO version and download it automatically (e.g., v1.2.3; Git tag or commit SHA).",
+    )
+
 
     parser.add_argument(
         "--act-whitelist-file",
@@ -312,6 +321,7 @@ def run(args=None) -> ReturnCode:
         extra_args=args.extra,
         merge_fbm=args.merge_fbm,
         fastbot_agent=args.fastbot_agent,
+        fastbot_so_version=args.fastbot_so_version,
     )
 
 

--- a/scripts/download_fastbot_so.py
+++ b/scripts/download_fastbot_so.py
@@ -1,0 +1,62 @@
+#!/usr/bin/env python3
+"""Download historical Fastbot native libraries into a local cache.
+
+The downloaded files are intended to be consumed by Kea2's future
+``--fastbot-so-version`` runtime option.  The requested version is used as a
+Git tag or commit ref on the Kea2 repositories.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+if __package__ in (None, ""):
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from kea2.fastbot_so_downloader import (
+    ABIS,
+    GIT_REF_PATTERN,
+    default_cache_dir,
+    ensure_libraries,
+    is_valid_library,
+    library_path,
+    missing_abis,
+    raw_library_urls,
+)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--version", required=True, help="Historical SO version (e.g., v1.2.3; Git tag or commit SHA).")
+    parser.add_argument("--cache-dir", type=Path, default=default_cache_dir(), help="Root directory for downloaded libraries.")
+    parser.add_argument("--force", action="store_true", help="Re-download libraries even when a valid cached file exists.")
+    parser.add_argument("--timeout", type=int, default=30, help="Per-file HTTP timeout in seconds.")
+    args = parser.parse_args(argv)
+    if args.timeout <= 0:
+        parser.error("--timeout must be greater than 0")
+    if not GIT_REF_PATTERN.fullmatch(args.version):
+        parser.error("--version must be a Git tag or commit ref containing only letters, digits, '.', '_' and '-'")
+    return args
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        root = ensure_libraries(
+            args.version,
+            cache_dir=args.cache_dir,
+            timeout=args.timeout,
+            force=args.force,
+            progress=print,
+        )
+    except (RuntimeError, ValueError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    print(f"Fastbot {args.version} libraries cached in {root}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/download_fastbot_so.py
+++ b/scripts/download_fastbot_so.py
@@ -16,14 +16,9 @@ if __package__ in (None, ""):
     sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
 
 from kea2.fastbot_so_downloader import (
-    ABIS,
     GIT_REF_PATTERN,
     default_cache_dir,
     ensure_libraries,
-    is_valid_library,
-    library_path,
-    missing_abis,
-    raw_library_urls,
 )
 
 

--- a/tests/test_download_fastbot_so.py
+++ b/tests/test_download_fastbot_so.py
@@ -1,0 +1,73 @@
+import importlib.util
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).parents[1]
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+fastbot_so_downloader = load_module(
+    "fastbot_so_downloader",
+    PROJECT_ROOT / "kea2" / "fastbot_so_downloader.py",
+)
+kea_launcher = load_module("kea_launcher", PROJECT_ROOT / "kea2" / "kea_launcher.py")
+download_fastbot_so = load_module("download_fastbot_so", PROJECT_ROOT / "scripts" / "download_fastbot_so.py")
+
+
+def test_library_urls_include_github_and_gitee_for_the_requested_version():
+    sources = dict(fastbot_so_downloader.raw_library_urls("v1.2.3", "arm64-v8a"))
+
+    assert sources["GitHub"].startswith("https://raw.githubusercontent.com/ecnusse/Kea2/v1.2.3/")
+    assert sources["GitHub"].endswith("/kea2/assets/fastbot_libs/arm64-v8a/libfastbot_native.so")
+    assert sources["Gitee"].startswith("https://gitee.com/XixianLiang/Kea2/raw/v1.2.3/")
+
+
+def test_missing_abis_reuses_valid_cached_libraries(tmp_path):
+    for abi in fastbot_so_downloader.ABIS:
+        path = fastbot_so_downloader.library_path(tmp_path, "v1.2.3", abi)
+        path.parent.mkdir(parents=True)
+        path.write_bytes(b"\x7fELFtest")
+
+    assert list(fastbot_so_downloader.missing_abis(tmp_path, "v1.2.3", force=False)) == []
+    assert list(fastbot_so_downloader.missing_abis(tmp_path, "v1.2.3", force=True)) == list(fastbot_so_downloader.ABIS)
+
+
+def test_parse_args_accepts_an_unlisted_version_and_rejects_invalid_refs():
+    args = download_fastbot_so.parse_args(["--version", "v9.9.9"])
+    assert args.version == "v9.9.9"
+
+    try:
+        download_fastbot_so.parse_args(["--version", "../../unexpected"])
+    except SystemExit as error:
+        assert error.code == 2
+    else:
+        raise AssertionError("unsupported versions must be rejected")
+
+
+def test_main_uses_gitee_when_github_download_fails(tmp_path, monkeypatch):
+    attempted_urls = []
+
+    def fake_download(url, destination, timeout):
+        attempted_urls.append(url)
+        if "raw.githubusercontent.com" in url:
+            raise fastbot_so_downloader.URLError("GitHub unavailable")
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        destination.write_bytes(b"\x7fELFtest")
+
+    monkeypatch.setattr(fastbot_so_downloader, "download_file", fake_download)
+    monkeypatch.setattr(fastbot_so_downloader, "is_valid_library", lambda path: path.exists())
+
+    assert fastbot_so_downloader.ensure_libraries("v1.2.3", cache_dir=tmp_path) == tmp_path / "v1.2.3"
+    assert len(attempted_urls) == len(fastbot_so_downloader.ABIS) * 2
+    assert all("gitee.com" in url for url in attempted_urls[1::2])
+
+
+def test_kea_cli_accepts_fastbot_so_version():
+    args = kea_launcher.parse_args(["run", "-p", "com.example.app", "--fastbot-so-version", "v1.2.3"])
+
+    assert args.fastbot_so_version == "v1.2.3"


### PR DESCRIPTION
## Summary
- add optional historical Fastbot SO version downloads with local caching
- use the selected SO version when pushing native libraries and log the version
- document the CLI option and add downloader tests

## Test
- uv run pytest tests/test_download_fastbot_so.py